### PR TITLE
feat: DTE-744 Add timeout

### DIFF
--- a/.github/workflows/_reusable_terraform_plan_apply_destroy.yml
+++ b/.github/workflows/_reusable_terraform_plan_apply_destroy.yml
@@ -98,6 +98,7 @@ jobs:
       - name: wait-for-approval
         if: ${{ inputs.needs_approval && inputs.run_apply && steps.terraform_plan.outputs.exitcode == 2}}
         uses: trstringer/manual-approval@v1
+        timeout-minutes: 90
         with:
           secret: ${{ github.TOKEN }}
           approvers: ${{ vars.APPROVERS }}


### PR DESCRIPTION
Adding a timeout to the manual approval so not to  burn billable minutes in the event of an approval going un-noticed