### PR TITLE
feat: Github build and ecr push workflows with and without code artifact

### DIFF
--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -15,33 +15,12 @@ inputs:
   ecr-registry-path:
     description: 'The path part of the repository name; i.e. the "alpha" in "alpha/docker-image-name"'
     required: true
-  aws-region:
-    description: 'The AWS region to deploy to'
-    required: true
-  aws-codeartifact-repository-name:
-    description: 'The AWS CodeArtifact repository to be used'
-    required: true
-  aws-codeartifact-repository-domain:
-    description: 'The domain of the AWS CodeArtifact repository to be used'
-    required: true
-  aws-codeartifact-repository-account:
-    description: 'The AWS account ID of the AWS CodeArtifact repository to be used'
-    required: true
-  pip-url-output-file:
-    description: 'Name of file to which pip access URL will be written'
-    default: 'pip-url.txt'
+  docker-build-arg:
+    description: 'Optional build arg to be used by docker'
     required: false
 runs:
   using: "composite"
   steps:
-    - name: Get AWS CodeArtifact pip URL
-      uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url@0.0.2
-      with:
-        repository: ${{ inputs.aws-codeartifact-repository-name }}
-        domain: ${{ inputs.aws-codeartifact-repository-domain }}
-        domain-owner: ${{ inputs.aws-codeartifact-repository-account }}
-        aws-region: ${{ inputs.aws-region }}
-        pip-url-output-file: ${{ inputs.pip-url-output-file }}
     - name: AWS ECR login
       id: aws-ecr-login
       uses: aws-actions/amazon-ecr-login@v1
@@ -54,20 +33,9 @@ runs:
         IMAGE_VERSION: ${{ inputs.image-version }}
         ECR_REPOSITORY_NAME: ${{ inputs.ecr-registry-path }}/${{ inputs.image-name }}
       run: |
-        echo "Local file listing follows:"
-        ls -la
-        echo "SHA256 of pip-url-output-file follows:"
-        shasum -a 256 "${{ inputs.pip-url-output-file }}"
-
-        echo "Exporting pip-url-output-file content in PIP_INDEX_URL:"
-        export PIP_INDEX_URL="$(cat "${{ inputs.pip-url-output-file }}")"
-
-        echo "SHA256 of PIP_INDEX_URL environment variable follows:"
-        echo "${PIP_INDEX_URL}" | shasum -a 256
-
         docker images
         docker build \
-          --build-arg PIP_INDEX_URL \
+          --build-arg ${{ inputs.docker-build-arg }} \
           --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \
           "${{ inputs.dockerfile-dir }}"
         docker images

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -35,13 +35,14 @@ runs:
       run: |
         docker images
         build_arg=""
-        if [ -n ${{ inputs.docker-build-arg }} ]; then
+        if [ -n "${{ inputs.docker-build-arg }}" ]; then
           build_arg="--build-arg ${{ inputs.docker-build-arg }} "
         fi
+        
         docker build \
-          $build_arg \
-          --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \
-          "${{ inputs.dockerfile-dir }}"
+        $build_arg \
+        --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \
+        "${{ inputs.dockerfile-dir }}"
         docker images
     - name: 'AWS ECR docker push'
       shell: bash

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -41,9 +41,7 @@ runs:
         if [ -n "${{ inputs.docker-build-arg }}" ]; then
           build_arg="--build-arg ${{ inputs.docker-build-arg }} "
         fi
-        
-        printf 'Using build arg "%s" for docker build' "${{ inputs.docker-build-arg }}"
-        
+                
         docker build \
         $build_arg \
         --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -43,8 +43,6 @@ runs:
           build_arg="--build-arg $arg_file_contents"
           printf 'Using build arg "%s" already exists' "${ECR_REPOSITORY_NAME}"
         fi
-        
-        printf 'Build arg "%s" built' "$build_arg"
       
         docker build \
         $build_arg \

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -39,7 +39,7 @@ runs:
         docker images
         build_arg=""
         if [ -n "${{ inputs.docker-build-arg-file }}" ]; then
-          arg_file_contents=`cat {{ $inputs.docker-build-arg-file }}`
+          arg_file_contents=$(cat "${{ inputs.docker-build-arg-file }}")
           build_arg="--build-arg $arg_file_contents"
         fi
                 

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -34,8 +34,12 @@ runs:
         ECR_REPOSITORY_NAME: ${{ inputs.ecr-registry-path }}/${{ inputs.image-name }}
       run: |
         docker images
+        build_arg=""
+        if [ -n ${{ inputs.docker-build-arg }} ]; then
+          build_arg="--build-arg ${{ inputs.docker-build-arg }} "
+        fi
         docker build \
-          --build-arg '${{ inputs.docker-build-arg }}' \
+          $build_arg' \
           --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \
           "${{ inputs.dockerfile-dir }}"
         docker images

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -42,7 +42,7 @@ runs:
           build_arg="--build-arg ${{ inputs.docker-build-arg }} "
         fi
         
-        printf $build_arg
+        printf 'Using build arg "%s" for docker build' "${{ inputs.docker-build-arg }}"
         
         docker build \
         $build_arg \

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -18,8 +18,8 @@ inputs:
   aws-region:
     description: 'AWS region'
     required: true
-  docker-build-arg:
-    description: 'Optional build arg to be used by docker'
+  docker-build-arg-file:
+    description: 'Optional file containing build arg to be used by docker'
     required: false
 runs:
   using: "composite"
@@ -39,7 +39,8 @@ runs:
         docker images
         build_arg=""
         if [ -n "${{ inputs.docker-build-arg }}" ]; then
-          build_arg="--build-arg ${{ inputs.docker-build-arg }} "
+          arg_file_contents=`cat {{ $inputs.docker-build-arg-file }}`
+          build_arg="--build-arg $arg_file_contents"
         fi
                 
         docker build \

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -18,8 +18,8 @@ inputs:
   aws-region:
     description: 'AWS region'
     required: true
-  docker-build-arg-file:
-    description: 'Optional file containing build arg to be used by docker'
+  pip-index-file:
+    description: 'Optional file containing pip index url to be supplied as a docker build argument'
     required: false
 runs:
   using: "composite"
@@ -38,9 +38,9 @@ runs:
       run: |
         docker images
         build_arg=""
-        if [ -n "${{ inputs.docker-build-arg-file }}" ]; then
-          arg_file_contents=$(cat "${{ inputs.docker-build-arg-file }}")
-          build_arg="--build-arg $arg_file_contents"
+        if [ -n "${{ inputs.pip-index-file }}" ]; then
+          pip_index_file_contents=$(cat "${{ inputs.pip-index-file }}")
+          build_arg="--build-arg PIP_INDEX_URL=$pip_index_file_contents"
         fi
       
         docker build \

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -42,6 +42,8 @@ runs:
           build_arg="--build-arg ${{ inputs.docker-build-arg }} "
         fi
         
+        printf $build_arg
+        
         docker build \
         $build_arg \
         --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -38,7 +38,7 @@ runs:
       run: |
         docker images
         build_arg=""
-        if [ -n "${{ inputs.docker-build-arg }}" ]; then
+        if [ -n "${{ inputs.docker-build-arg-file }}" ]; then
           arg_file_contents=`cat {{ $inputs.docker-build-arg-file }}`
           build_arg="--build-arg $arg_file_contents"
         fi

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         docker images
         docker build \
-          ${{ if ne(inputs.docker-build-arg, '') }}--build-arg ${{ inputs.docker-build-arg }} ${{ end }} \
+          --build-arg '${{ inputs.docker-build-arg }}' \
           --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \
           "${{ inputs.dockerfile-dir }}"
         docker images

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -39,7 +39,7 @@ runs:
           build_arg="--build-arg ${{ inputs.docker-build-arg }} "
         fi
         docker build \
-          $build_arg' \
+          $build_arg \
           --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \
           "${{ inputs.dockerfile-dir }}"
         docker images

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -41,8 +41,11 @@ runs:
         if [ -n "${{ inputs.docker-build-arg-file }}" ]; then
           arg_file_contents=$(cat "${{ inputs.docker-build-arg-file }}")
           build_arg="--build-arg $arg_file_contents"
+          printf 'Using build arg "%s" already exists' "${ECR_REPOSITORY_NAME}"
         fi
-                
+        
+        printf 'Build arg "%s" built' "$build_arg"
+      
         docker build \
         $build_arg \
         --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -41,7 +41,6 @@ runs:
         if [ -n "${{ inputs.docker-build-arg-file }}" ]; then
           arg_file_contents=$(cat "${{ inputs.docker-build-arg-file }}")
           build_arg="--build-arg $arg_file_contents"
-          printf 'Using build arg "%s" already exists' "${ECR_REPOSITORY_NAME}"
         fi
       
         docker build \

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         docker images
         docker build \
-          --build-arg ${{ inputs.docker-build-arg }} \
+          ${{ if ne(inputs.docker-build-arg, '') }}--build-arg ${{ inputs.docker-build-arg }} ${{ end }} \
           --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \
           "${{ inputs.dockerfile-dir }}"
         docker images

--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -15,6 +15,9 @@ inputs:
   ecr-registry-path:
     description: 'The path part of the repository name; i.e. the "alpha" in "alpha/docker-image-name"'
     required: true
+  aws-region:
+    description: 'AWS region'
+    required: true
   docker-build-arg:
     description: 'Optional build arg to be used by docker'
     required: false

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -34,4 +34,4 @@ runs:
         )"
 
         echo pip_index_url="https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
-          >> $GITHUB_OUTPUT
+          >> "$GITHUB_OUTPUT"

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -22,7 +22,6 @@ runs:
   using: "composite"
   steps:
     - name: AWS CodeArtifact login
-      id: get-pip-index-url
       shell: bash
       run: |
         CA_AUTH_TOKEN="$( \
@@ -34,4 +33,4 @@ runs:
           --output text \
         )"
 
-        echo "pip_index_url=https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" >> $GITHUB_OUTPUT
+        echo "pip_index_url=https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" >> $GITHUB_ENV

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -36,7 +36,7 @@ runs:
           --output text \
         )"
 
-        echo "https://:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
+        echo "https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
           > "${{ inputs.pip-url-output-file }}"
 
         echo "Local file listing follows:"

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -1,4 +1,4 @@
-# Action to log in to AWS CodeArtifact; saves pip/pypi access URL to named file.
+# Action to log in to AWS CodeArtifact; saves pip/pypi access URL to named file.
 name: 'AWS CodeArtifact Repository Login'
 description: 'Log in to an AWS CodeArtifact repository'
 inputs:
@@ -18,6 +18,9 @@ inputs:
   aws-region:
     description: 'The AWS region in which the CodeArtifact repository resides'
     required: true
+  pip-url-output-file:
+    description: 'Name of file to which pip access URL will be written'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -33,4 +36,11 @@ runs:
           --output text \
         )"
 
-        echo "pip_index_url=https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" >> $GITHUB_ENV
+        echo "https://:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
+          > "${{ inputs.pip-url-output-file }}"
+
+        echo "Local file listing follows:"
+        ls -la
+
+        echo "SHA256 of pip-url-output-file follows:"
+        shasum -a 256 "${{ inputs.pip-url-output-file }}"

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -33,4 +33,4 @@ runs:
           --output text \
         )"
 
-        echo "pip_index_url=https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" >> "$GITHUB_OUTPUT"
+        echo "pip_index_url=https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" >> $GITHUB_OUTPUT

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -21,7 +21,6 @@ inputs:
   pip-url-output-file:
     description: 'Name of file to which pip access URL will be written'
     required: true
-
 runs:
   using: "composite"
   steps:

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -15,14 +15,8 @@ inputs:
     description: 'Seconds until generated auth token expires'
     default: '900'
     required: false
-  pypi-url-username:
-    description: 'The username used in the URL to access AWS CodeArtifact'
-    required: true
   aws-region:
     description: 'The AWS region in which the CodeArtifact repository resides'
-    required: true
-  pip-url-output-file:
-    description: 'Name of file to which pip access URL will be written'
     required: true
 runs:
   using: "composite"
@@ -39,11 +33,5 @@ runs:
           --output text \
         )"
 
-        echo "https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
-          > "${{ inputs.pip-url-output-file }}"
-
-        echo "Local file listing follows:"
-        ls -la
-
-        echo "SHA256 of pip-url-output-file follows:"
-        shasum -a 256 "${{ inputs.pip-url-output-file }}"
+        echo pip_index_url="https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
+          >> $GITHUB_OUTPUT

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -15,9 +15,6 @@ inputs:
     description: 'Seconds until generated auth token expires'
     default: '900'
     required: false
-  pypi-url-username:
-    description: 'The username used in the URL to access AWS CodeArtifact'
-    required: true
   aws-region:
     description: 'The AWS region in which the CodeArtifact repository resides'
     required: true
@@ -40,7 +37,7 @@ runs:
           --output text \
         )"
 
-        echo "https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
+        echo "PIP_INDEX_URL=https://:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
           > "${{ inputs.pip-url-output-file }}"
 
         echo "Local file listing follows:"

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -37,7 +37,7 @@ runs:
           --output text \
         )"
 
-        echo "PIP_INDEX_URL=https://:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
+        echo "https://:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
           > "${{ inputs.pip-url-output-file }}"
 
         echo "Local file listing follows:"

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -22,6 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: AWS CodeArtifact login
+      id: get-pip-index-url
       shell: bash
       run: |
         CA_AUTH_TOKEN="$( \

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -33,5 +33,4 @@ runs:
           --output text \
         )"
 
-        echo pip_index_url="https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" \
-          >> "$GITHUB_OUTPUT"
+        echo "pip_index_url=https://${{ inputs.pypi-url-username }}:${CA_AUTH_TOKEN}@${{ inputs.domain }}-${{ inputs.domain-owner }}.d.codeartifact.${{ inputs.aws-region }}.amazonaws.com/pypi/${{ inputs.repository }}/simple/" >> "$GITHUB_OUTPUT"

--- a/.github/actions/get-aws-codeartifact-pip-url/action.yml
+++ b/.github/actions/get-aws-codeartifact-pip-url/action.yml
@@ -15,12 +15,16 @@ inputs:
     description: 'Seconds until generated auth token expires'
     default: '900'
     required: false
+  pypi-url-username:
+    description: 'The username used in the URL to access AWS CodeArtifact'
+    required: true
   aws-region:
     description: 'The AWS region in which the CodeArtifact repository resides'
     required: true
   pip-url-output-file:
     description: 'Name of file to which pip access URL will be written'
     required: true
+
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -66,6 +66,9 @@ jobs:
           domain: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_DOMAIN }}
           domain-owner: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_ACCOUNT }}
           aws-region: ${{ secrets.AWS_REGION }}
+      - name: More diagnostic info
+        run: |
+          printf 'steps.get-pip-index-url.outputs.pip_index_url=%s\n' "${{ steps.get-pip-index-url.outputs.pip_index_url}}"
       - name: Build and push Docker image to AWS ECR
         uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact
         with:

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -17,6 +17,18 @@ on:
       ecr_registry_path:
         type: string
         required: true
+    # Define secrets to be passed from calling workflow
+    secrets:
+      AWS_OPEN_ID_CONNECT_ROLE_ARN:
+        required: true
+      AWS_CODEARTIFACT_REPOSITORY_NAME:
+        required: true
+      AWS_CODEARTIFACT_REPOSITORY_DOMAIN:
+        required: true
+      AWS_CODEARTIFACT_REPOSITORY_ACCOUNT:
+        required: true
+      AWS_REGION:
+        required: true
 permissions:
   id-token: write  # required by aws-actions/configure-aws-credentials
   contents: write  # to push new git tag
@@ -46,6 +58,14 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           # triggering-actor could differ for re-runs: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           role-session-name: role-session-name-${{ github.actor }}-${{ github.triggering_actor }}
+      - name: Get AWS CodeArtifact pip URL
+        uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url@0.0.2
+        id: get-pip-index-url
+        with:
+          repository: ${{ inputs.aws-codeartifact-repository-name }}
+          domain: ${{ inputs.aws-codeartifact-repository-domain }}
+          domain-owner: ${{ inputs.aws-codeartifact-repository-account }}
+          aws-region: ${{ inputs.aws-region }}
       - name: Build and push Docker image to AWS ECR
         uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@0.0.2
         with:
@@ -53,6 +73,7 @@ jobs:
           image-name: ${{ inputs.docker_image_name }}
           image-version: ${{ steps.build-tag.outputs.next-version }}
           ecr-registry-path: ${{ inputs.ecr_registry_path }}
+          docker-build-arg: ${{ steps.get-pip-index-url.outputs.pip_index_url }}
       - name: Add Git tag for this build
         run: |
           git tag ${{ steps.build-tag.outputs.next-version }}

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -62,9 +62,9 @@ jobs:
         uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url@feature/DTE-822-github-workflows-with-and-without-codeartifact
         id: get-pip-index-url
         with:
-          repository: ${{ inputs.aws-codeartifact-repository-name }}
-          domain: ${{ inputs.aws-codeartifact-repository-domain }}
-          domain-owner: ${{ inputs.aws-codeartifact-repository-account }}
+          repository: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_NAME }}
+          domain: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_DOMAIN }}
+          domain-owner: ${{ AWS_CODEARTIFACT_REPOSITORY_ACCOUNT }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Build and push Docker image to AWS ECR
         uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -66,9 +66,9 @@ jobs:
           domain: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_DOMAIN }}
           domain-owner: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_ACCOUNT }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: More diagnostic info
+      - name: Diagnostic info
         run: |
-          printf 'steps.get-pip-index-url.outputs%s\n' "${{ steps.get-pip-index-url.outputs }}"
+          printf 'steps.get-pip-index-url.outputs.pip_index_url%s\n' "${{ steps.get-pip-index-url.outputs.pip_index_url }}"
       - name: Build and push Docker image to AWS ECR
         uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact
         with:

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -65,7 +65,7 @@ jobs:
           repository: ${{ inputs.aws-codeartifact-repository-name }}
           domain: ${{ inputs.aws-codeartifact-repository-domain }}
           domain-owner: ${{ inputs.aws-codeartifact-repository-account }}
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ secrets.AWS_REGION }}
       - name: Build and push Docker image to AWS ECR
         uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact
         with:
@@ -73,6 +73,7 @@ jobs:
           image-name: ${{ inputs.docker_image_name }}
           image-version: ${{ steps.build-tag.outputs.next-version }}
           ecr-registry-path: ${{ inputs.ecr_registry_path }}
+          aws-region: ${{ secrets.AWS_REGION }}
           docker-build-arg: ${{ steps.get-pip-index-url.outputs.pip_index_url }}
       - name: Add Git tag for this build
         run: |

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -64,7 +64,7 @@ jobs:
           # triggering-actor could differ for re-runs: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           role-session-name: role-session-name-${{ github.actor }}-${{ github.triggering_actor }}
       - name: Save AWS CodeArtifact pip URL to file
-        uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url@feature/DTE-822-github-workflows-with-and-without-codeartifact
+        uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url
         with:
           repository: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_NAME }}
           domain: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_DOMAIN }}
@@ -72,7 +72,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           pip-url-output-file: ${{ inputs.pip_url_output_file }}
       - name: Build and push Docker image to AWS ECR
-        uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact
+        uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr
         with:
           dockerfile-dir: ${{ inputs.build_dir }}
           image-name: ${{ inputs.docker_image_name }}

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -67,7 +67,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Diagnostic info
         run: |
-          printf 'steps.get-pip-index-url.outputs.pip_index_url%s\n' "${{ steps.get-pip-index-url.outputs.pip_index_url }}"
+          printf 'env.pip_index_url%s\n' "${{ env.pip_index_url }}"
       - name: Build and push Docker image to AWS ECR
         uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact
         with:
@@ -76,7 +76,7 @@ jobs:
           image-version: ${{ steps.build-tag.outputs.next-version }}
           ecr-registry-path: ${{ inputs.ecr_registry_path }}
           aws-region: ${{ secrets.AWS_REGION }}
-          docker-build-arg: ${{ steps.get-pip-index-url.outputs.pip_index_url }}
+          docker-build-arg: ${{ env.pip_index_url }}
       - name: Add Git tag for this build
         run: |
           git tag ${{ steps.build-tag.outputs.next-version }}

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -68,7 +68,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: More diagnostic info
         run: |
-          printf 'steps.get-pip-index-url.outputs.pip_index_url=%s\n' "${{ steps.get-pip-index-url.outputs.pip_index_url}}"
+          printf 'steps.get-pip-index-url.outputs%s\n' "${{ steps.get-pip-index-url.outputs }}"
       - name: Build and push Docker image to AWS ECR
         uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact
         with:

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -59,7 +59,7 @@ jobs:
           # triggering-actor could differ for re-runs: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           role-session-name: role-session-name-${{ github.actor }}-${{ github.triggering_actor }}
       - name: Get AWS CodeArtifact pip URL
-        uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url@0.0.2
+        uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url@@feature/DTE-822-github-workflows-with-and-without-codeartifact
         id: get-pip-index-url
         with:
           repository: ${{ inputs.aws-codeartifact-repository-name }}
@@ -67,7 +67,7 @@ jobs:
           domain-owner: ${{ inputs.aws-codeartifact-repository-account }}
           aws-region: ${{ inputs.aws-region }}
       - name: Build and push Docker image to AWS ECR
-        uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@0.0.2
+        uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact
         with:
           dockerfile-dir: ${{ inputs.build_dir }}
           image-name: ${{ inputs.docker_image_name }}

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -59,7 +59,7 @@ jobs:
           # triggering-actor could differ for re-runs: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           role-session-name: role-session-name-${{ github.actor }}-${{ github.triggering_actor }}
       - name: Get AWS CodeArtifact pip URL
-        uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url@@feature/DTE-822-github-workflows-with-and-without-codeartifact
+        uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url@feature/DTE-822-github-workflows-with-and-without-codeartifact
         id: get-pip-index-url
         with:
           repository: ${{ inputs.aws-codeartifact-repository-name }}

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           repository: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_NAME }}
           domain: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_DOMAIN }}
-          domain-owner: ${{ AWS_CODEARTIFACT_REPOSITORY_ACCOUNT }}
+          domain-owner: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_ACCOUNT }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Build and push Docker image to AWS ECR
         uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -79,7 +79,7 @@ jobs:
           image-version: ${{ steps.build-tag.outputs.next-version }}
           ecr-registry-path: ${{ inputs.ecr_registry_path }}
           aws-region: ${{ secrets.AWS_REGION }}
-          docker-build-arg-file: ${{ inputs.pip_url_output_file }}
+          pip-index-file: ${{ inputs.pip_url_output_file }}
       - name: Add Git tag for this build
         run: |
           git tag ${{ steps.build-tag.outputs.next-version }}

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -60,7 +60,6 @@ jobs:
           role-session-name: role-session-name-${{ github.actor }}-${{ github.triggering_actor }}
       - name: Get AWS CodeArtifact pip URL
         uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url@feature/DTE-822-github-workflows-with-and-without-codeartifact
-        id: get-pip-index-url
         with:
           repository: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_NAME }}
           domain: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_DOMAIN }}

--- a/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy-using-code-artifact.yml
@@ -17,6 +17,11 @@ on:
       ecr_registry_path:
         type: string
         required: true
+      pip_url_output_file:
+        type: string
+        description: 'Name of file to which pip access URL will be written'
+        default: 'pip-url.txt'
+        required: false
     # Define secrets to be passed from calling workflow
     secrets:
       AWS_OPEN_ID_CONNECT_ROLE_ARN:
@@ -58,16 +63,14 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           # triggering-actor could differ for re-runs: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           role-session-name: role-session-name-${{ github.actor }}-${{ github.triggering_actor }}
-      - name: Get AWS CodeArtifact pip URL
+      - name: Save AWS CodeArtifact pip URL to file
         uses: nationalarchives/da-tre-github-actions/.github/actions/get-aws-codeartifact-pip-url@feature/DTE-822-github-workflows-with-and-without-codeartifact
         with:
           repository: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_NAME }}
           domain: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_DOMAIN }}
           domain-owner: ${{ secrets.AWS_CODEARTIFACT_REPOSITORY_ACCOUNT }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Diagnostic info
-        run: |
-          printf 'env.pip_index_url%s\n' "${{ env.pip_index_url }}"
+          pip-url-output-file: ${{ inputs.pip_url_output_file }}
       - name: Build and push Docker image to AWS ECR
         uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact
         with:
@@ -76,7 +79,7 @@ jobs:
           image-version: ${{ steps.build-tag.outputs.next-version }}
           ecr-registry-path: ${{ inputs.ecr_registry_path }}
           aws-region: ${{ secrets.AWS_REGION }}
-          docker-build-arg: ${{ env.pip_index_url }}
+          docker-build-arg-file: ${{ inputs.pip_url_output_file }}
       - name: Add Git tag for this build
         run: |
           git tag ${{ steps.build-tag.outputs.next-version }}

--- a/.github/workflows/docker-build-and-ecr-deploy.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy.yml
@@ -53,7 +53,7 @@ jobs:
           # triggering-actor could differ for re-runs: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           role-session-name: role-session-name-${{ github.actor }}-${{ github.triggering_actor }}
       - name: Build and push Docker image to AWS ECR
-        uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@0.0.2
+        uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact
         with:
           dockerfile-dir: ${{ inputs.build_dir }}
           image-name: ${{ inputs.docker_image_name }}

--- a/.github/workflows/docker-build-and-ecr-deploy.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy.yml
@@ -53,7 +53,7 @@ jobs:
           # triggering-actor could differ for re-runs: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           role-session-name: role-session-name-${{ github.actor }}-${{ github.triggering_actor }}
       - name: Build and push Docker image to AWS ECR
-        uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr@feature/DTE-822-github-workflows-with-and-without-codeartifact
+        uses: nationalarchives/da-tre-github-actions/.github/actions/docker-build-and-deploy-to-ecr
         with:
           dockerfile-dir: ${{ inputs.build_dir }}
           image-name: ${{ inputs.docker_image_name }}

--- a/.github/workflows/docker-build-and-ecr-deploy.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy.yml
@@ -17,6 +17,12 @@ on:
       ecr_registry_path:
         type: string
         required: true
+    # Define secrets to be passed from calling workflow
+    secrets:
+      AWS_OPEN_ID_CONNECT_ROLE_ARN:
+        required: true
+      AWS_REGION:
+        required: true
 permissions:
   id-token: write  # required by aws-actions/configure-aws-credentials
   contents: write  # to push new git tag

--- a/.github/workflows/docker-build-and-ecr-deploy.yml
+++ b/.github/workflows/docker-build-and-ecr-deploy.yml
@@ -59,6 +59,7 @@ jobs:
           image-name: ${{ inputs.docker_image_name }}
           image-version: ${{ steps.build-tag.outputs.next-version }}
           ecr-registry-path: ${{ inputs.ecr_registry_path }}
+          aws-region: ${{ secrets.AWS_REGION }}
       - name: Add Git tag for this build
         run: |
           git tag ${{ steps.build-tag.outputs.next-version }}


### PR DESCRIPTION
This makes available two separate workflows for our python and scala lambdas. The `docker-build-and-ecr-deploy` workflow has the secrets required for fetching dependencies via code artifact stripped out, calling the `docker-build-and-deploy-to-ecr` action without an optional `pip-index-file` for extracting a pip index URL. `docker-build-and-ecr-deploy-using-code-artifact` should work out of the box with our existing python lambdas, constructing a pip index url and supplying its file as an argument to the generalised docker build action.

On landing, PRs will follow to update our python lambdas to point at the new `-using-code-artifact` workflow, but this shouldn't be a breaking change as their existing workflow references are tagged.

## Test Plan

Called `docker-build-and-ecr-deploy` from branch in `da-tre-fn-template`, verified image created in ECR.

Called `docker-build-and-ecr-deploy-with-code-artifact` from existing workflow in `da-tre-fn-court-document-packer`. Updated pte to use created image and smoketested using `da-tre-system-testing`.

