### PR TITLE
chore: Only run systems tests if terraform has planned changes

### DIFF
--- a/.github/workflows/_reusable_terraform_plan_apply_destroy.yml
+++ b/.github/workflows/_reusable_terraform_plan_apply_destroy.yml
@@ -132,7 +132,7 @@ jobs:
           TESTING_ENVIRONMENT=$(jq -r '.environment_name' ssm.tfvars.json)
           echo "TESTING_ENVIRONMENT=$TESTING_ENVIRONMENT" >> $GITHUB_ENV
       - name: Run system tests
-        if: inputs.run_system_tests == true
+        if: ${{ inputs.run_system_tests && steps.terraform_plan.outputs.exitcode == 2 }}
         uses: nationalarchives/da-tre-github-actions/.github/actions/run-system-tests@0.0.19
         with:
           source_role: ${{ secrets.TESTING_SOURCE_ROLE }}


### PR DESCRIPTION
If our deploy times out, we don't want to run the full suite of systems tests again on the same infrastructure.