### PR TITLE
Remove TF_WORKSPACE env var

### DIFF
--- a/.github/workflows/_reusable_terraform_plan_apply_destroy.yml
+++ b/.github/workflows/_reusable_terraform_plan_apply_destroy.yml
@@ -98,11 +98,11 @@ jobs:
           terraform_wrapper: true
       - name: Terraform init
         env:
-          TF_WORKSPACE: ${{ inputs.workspace }}
+          WORKSPACE_NAME: ${{ inputs.workspace }}
         run: |
           terraform init -reconfigure --backend-config=backend.conf
           terraform workspace list
-          terraform workspace select "${TF_WORKSPACE}"
+          terraform workspace select "$WORKSPACE_NAME"
       - name: Terraform plan
         if: inputs.run_destroy == false
         id: terraform_plan


### PR DESCRIPTION
Terraform is now more strict about having the TF_WORKSPACE environment
variable and calling `workspace select` I've changed the name of the environment
variable so this should stop terraform erroring.
